### PR TITLE
Adding advanced settings

### DIFF
--- a/src/command/handler/handle_deployment.rs
+++ b/src/command/handler/handle_deployment.rs
@@ -1,5 +1,5 @@
 use crate::command::types::{DeploymentOpt, OutputFormat};
-use crate::subquery::{CreateDeployRequest, DeploymentType};
+use crate::subquery::{CreateDeployRequest, DeploymentType, build_advanced};
 use crate::{Subquery, SubqueryError};
 
 pub async fn handle_deployment(subquery: &Subquery, opt: DeploymentOpt) -> color_eyre::Result<()> {
@@ -22,7 +22,7 @@ pub async fn handle_deployment(subquery: &Subquery, opt: DeploymentOpt) -> color
         query_image_version: command.query_image_version,
         type_: command.type_,
         sub_folder: command.sub_folder,
-        indexer_batch_size: command.indexer_batch_size,
+        advanced_settings: build_advanced(command.batch_size, command.subscription)
       };
       handle_deploy(
         subquery,
@@ -51,7 +51,7 @@ pub async fn handle_deployment(subquery: &Subquery, opt: DeploymentOpt) -> color
         query_image_version: command.query_image_version,
         type_: command.type_,
         sub_folder: command.sub_folder,
-        indexer_batch_size: command.indexer_batch_size
+        advanced_settings: build_advanced(command.batch_size, command.subscription)
       };
       handle_redeploy(
         subquery,

--- a/src/command/types.rs
+++ b/src/command/types.rs
@@ -183,7 +183,10 @@ pub struct DeployCommand {
   pub sub_folder: Option<String>,
   /// Batch size for indexer
   #[structopt(long, default_value = "30")]
-  pub indexer_batch_size: u32,
+  pub batch_size: u32,
+  /// Subscription activation
+  #[structopt(long)]
+  pub subscription: bool,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/subquery/types.rs
+++ b/src/subquery/types.rs
@@ -134,8 +134,8 @@ pub struct CreateDeployRequest {
   pub type_: DeploymentType,
   #[serde(rename = "subFolder", with = "string_empty_as_none")]
   pub sub_folder: Option<String>,
-  #[serde(rename = "indexerBatchSize")]
-  pub indexer_batch_size: u32,
+  #[serde(rename = "advancedSettings")]
+  pub advanced_settings: AdvancedSettings
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, EnumString, EnumVariantNames)]
@@ -214,8 +214,8 @@ pub struct DeployRequest {
   pub query_image_version: String,
   #[serde(rename = "type")]
   pub type_: DeploymentType,
-  #[serde(rename = "indexerBatchSize")]
-  pub indexer_batch_size: u32,
+  #[serde(rename = "advancedSettings")]
+  pub advanced: AdvancedSettings,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -243,4 +243,36 @@ pub struct LogResult {
   pub message: String,
   pub category: String,
   pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubIndexerSettings {
+  #[serde(rename = "batchSize")]
+  pub batch_size: u32,
+  pub subscription: bool
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubQuerySettings {
+  pub subscription: bool
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AdvancedSettings {
+  #[serde(rename = "@subql/node")]
+  pub subql_node: SubIndexerSettings,
+  #[serde(rename = "@subql/query")]
+  pub subql_query: SubQuerySettings
+}
+
+pub fn build_advanced(batch: u32, sub: bool) -> AdvancedSettings {
+  return AdvancedSettings {
+    subql_node: SubIndexerSettings {
+      batch_size: batch,
+      subscription: sub.clone()
+    },
+    subql_query: SubQuerySettings{
+      subscription: sub.clone()
+    }
+  }
 }

--- a/src/subquery/types.rs
+++ b/src/subquery/types.rs
@@ -266,7 +266,7 @@ pub struct AdvancedSettings {
 }
 
 pub fn build_advanced(batch: u32, sub: bool) -> AdvancedSettings {
-  return AdvancedSettings {
+  AdvancedSettings {
     subql_node: SubIndexerSettings {
       batch_size: batch,
       subscription: sub

--- a/src/subquery/types.rs
+++ b/src/subquery/types.rs
@@ -269,10 +269,10 @@ pub fn build_advanced(batch: u32, sub: bool) -> AdvancedSettings {
   return AdvancedSettings {
     subql_node: SubIndexerSettings {
       batch_size: batch,
-      subscription: sub.clone()
+      subscription: sub
     },
     subql_query: SubQuerySettings{
-      subscription: sub.clone()
+      subscription: sub
     }
   }
 }


### PR DESCRIPTION
This PR is updating deployment state by adding advancedSettings which provide batch size and subscriptions.

Example of request:
./target/release/subquery --token some_token deployment deploy --branch master --indexer-image-version v0.33.0 --key test-project --org stepanLav --query-image-version v0.14.1

```bash
{
  "version": "d62369346370689935ad68db1c970302e7243b60",
  "endpoint": "",
  "dictEndpoint": "",
  "indexerImageVersion": "v0.33.0",
  "queryImageVersion": "v0.14.1",
  "type": "stage",
  "subFolder": "",
  "advancedSettings": {
    "@subql/node": {
      "batchSize": 30,
      "subscription": false
    },
    "@subql/query": {
      "subscription": false
    }
  }
}
```